### PR TITLE
Refs 2083: change pulp TaskResponse.Error type to string

### DIFF
--- a/.github/workflows/pulp.yml
+++ b/.github/workflows/pulp.yml
@@ -65,6 +65,7 @@ jobs:
           sed -i "0,/docs_api\.json_get/{s/docs_api\.json_get/docs_api\.json_get_1/}" ./pulp_api.json
           sed -i "0,/status_read/{s/status_read/status_read_1/}" ./pulp_api.json
           sed -i "0,/docs_api\.yaml_get/{s/docs_api\.yaml_get/docs_api\.yaml_get_1/}" ./pulp_api.json
+          echo "$( jq '.components.schemas.TaskResponse.properties.error.additionalProperties.type = "string"' ./pulp_api.json )" > ./pulp_api.json
           docker run --network=host --rm -v ${PWD}:/local openapitools/openapi-generator-cli generate \
           -i /local/pulp_api.json \
           -t /local/templates/ \

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Directories
+.idea


### PR DESCRIPTION
Manually change pulp_api.json to correct the type of the properties in TaskResponse.Error

Currently looks like:

```
 "TaskResponse":  {
...
    "error":  
       {
           "type": "object",
           "additionalProperties": {
                "type": "object"
            },
               "readOnly": true,
                "description": "A JSON Object of a fatal error encountered during the execution of this task."
      }
...
}
```

Should look like:
```
 "TaskResponse":  {
...
    "error":  
       {
           "type": "object",
           "additionalProperties": {
                "type": "string"
            },
               "readOnly": true,
                "description": "A JSON Object of a fatal error encountered during the execution of this task."
      }
...
}
```

Because the values of the fields in the error object are string:
```
"error": {
    "traceback": "  File \"/...",
    "description": "Cannot connect..."
  },
```

And according to [this]( https://swagger.io/docs/specification/data-models/dictionaries/) "The additionalProperties keyword specifies the type of values in the dictionary."

